### PR TITLE
Update to latest symfony/expression-language

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "symfony/expression-language": "^2.8",
+        "symfony/expression-language": "^2.8|^4.0",
         "s1lentium/iptools": "^1.1"
     },
     "autoload": {


### PR DESCRIPTION
No obvious BC impact are found according to current test suite. The 2.x component conflicts with symfony 4 ones.