### PR TITLE
fix #57 enforcer logic when there is no policy found

### DIFF
--- a/src/Enforcer.php
+++ b/src/Enforcer.php
@@ -7,6 +7,7 @@ namespace Casbin;
 use Casbin\Effect\DefaultEffector;
 use Casbin\Effect\Effector;
 use Casbin\Exceptions\CasbinException;
+use Casbin\Exceptions\EvalFunctionException;
 use Casbin\Exceptions\InvalidFilePathException;
 use Casbin\Model\FunctionMap;
 use Casbin\Model\Model;
@@ -557,7 +558,6 @@ class Enforcer
         $hasEval = Util::hasEval($expString);
 
         if (!$hasEval) {
-            $expressionLanguage = $this->getExpressionLanguage($functions);
             $expression = $expressionLanguage->parse($expString, array_merge($rTokens, $pTokens));
         }
 
@@ -628,6 +628,10 @@ class Enforcer
                 }
             }
         } else {
+            if ($hasEval) {
+                throw new EvalFunctionException("please make sure rule exists in policy when using eval() in matcher");
+            }
+
             $parameters = $rParameters;
             foreach ($this->model['p']['p']->tokens as $token) {
                 $parameters[$token] = '';

--- a/src/Enforcer.php
+++ b/src/Enforcer.php
@@ -554,7 +554,6 @@ class Enforcer
         }
 
         $expressionLanguage = $this->getExpressionLanguage($functions);
-        $expression = new ExpressionLanguage();
         $hasEval = Util::hasEval($expString);
 
         if (!$hasEval) {

--- a/src/Exceptions/EvalFunctionException.php
+++ b/src/Exceptions/EvalFunctionException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Casbin\Exceptions;
+
+
+class EvalFunctionException extends CasbinException
+{
+
+}

--- a/tests/Unit/Model/ModelTest.php
+++ b/tests/Unit/Model/ModelTest.php
@@ -3,6 +3,7 @@
 namespace Casbin\Tests\Unit\Model;
 
 use Casbin\Enforcer;
+use Casbin\Exceptions\EvalFunctionException;
 use Casbin\Model\Model;
 use Casbin\Util\BuiltinOperations;
 use PHPUnit\Framework\TestCase;
@@ -71,6 +72,18 @@ EOT;
         $this->assertEquals($e->enforce($sub3, '/data2', 'read'), false);
         $this->assertEquals($e->enforce($sub3, '/data1', 'write'), false);
         $this->assertEquals($e->enforce($sub3, '/data2', 'write'), false);
+    }
+
+    public function testEvalFunctionException()
+    {
+        $this->expectException(EvalFunctionException::class);
+        $this->expectExceptionMessage("please make sure rule exists in policy when using eval() in matcher");
+
+        $e = new Enforcer($this->modelAndPolicyPath.'/abac_rule_model.conf', "");
+
+        $sub1 = new User('alice', 18);
+
+        $e->enforce($sub1, '/data1', 'read');
     }
   
     public function testRBACModelWithPattern()


### PR DESCRIPTION
Fix: https://github.com/php-casbin/php-casbin/issues/57

When your use `eval()` in matcher whthout use the policy.
@techoner please review.