### PR TITLE
fix:request type check

### DIFF
--- a/src/CoreEnforcer.php
+++ b/src/CoreEnforcer.php
@@ -604,6 +604,14 @@ class CoreEnforcer
                 break;
         }
 
+        foreach ($rvals as $rinx => $rval) {
+            if (\is_string($rval) || \method_exists($rval, '__toString')){
+                continue;
+            }
+            \trigger_error(\sprintf('rvals %d must be of the type Stringable, %s given', $rinx, \gettype($rval)), \E_USER_WARNING);
+            $rvals[$rinx] = \strval($rval);
+        }
+
         $expString = '';
         if ('' === $matcher) {
             $expString = $this->model['m'][$mType]->value;


### PR DESCRIPTION
最近使用casbin中发现一个小问题，我不确定这是否casbin设计如此。

```
[request_definition]
r = sub, obj, act

[policy_definition]
p = sub, obj, act

[policy_effect]
e = some(where (p.eft == allow))

[matchers]
m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
```
如上述model。php作为弱类型语言，下面的代码是可以通过检查的。
```
Enforce::enforce(true, true, true);
```
而如果将model修改如下，在多语言的项目中，我不确定是否可以通用。
```
[matchers]
m = r.sub === p.sub && r.obj === p.obj && r.act === p.act
```
我大概看了下golang的实现，接收的参数是`interface{}`，因此我不清楚这是否casbin的设计，对参数的校验放在用户层面。

我提交了pr，对非`Stringable`的参数，报告`E_USER_WARNING`。因为我不确定如果被合并，`throw Exception`是否会影响他人使用。
