### PR TITLE
feat: Implemented variable order field index

### DIFF
--- a/examples/priority_model_explicit_customized.conf
+++ b/examples/priority_model_explicit_customized.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = subject, obj, act
+
+[policy_definition]
+p = customized_priority, obj, act, eft, subject
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = priority(p.eft) || deny
+
+[matchers]
+m = g(r.subject, p.subject) && r.obj == p.obj && r.act == p.act

--- a/examples/priority_policy_explicit_customized.csv
+++ b/examples/priority_policy_explicit_customized.csv
@@ -1,0 +1,12 @@
+p, 10, data1, read, deny, data1_deny_group
+p, 10, data1, write, deny, data1_deny_group
+p, 10, data2, read, allow, data2_allow_group
+p, 10, data2, write, allow, data2_allow_group
+
+
+p, 1, data1, write, allow, alice
+p, 1, data1, read, allow, alice
+p, 1, data2, read, deny, bob
+
+g, bob, data2_allow_group
+g, alice, data1_deny_group

--- a/src/Constant/Constants.php
+++ b/src/Constant/Constants.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Casbin\Constant;
+
+/**
+ * Class Constant
+ * Contains constants used in Casbin.
+ *
+ * @author 1692898084@qq.com
+ */
+final class Constants
+{
+    const ACTION_INDEX = 'act';
+    const DOMAIN_INDEX = 'dom';
+    const SUBJECT_INDEX = 'sub';
+    const OBJECT_INDEX = 'obj';
+    const PRIORITY_INDEX = 'priority';
+
+    const ALLOW_OVERRIDE_EFFECT = 'some(where (p_eft == allow))';
+    const DENY_OVERRIDE_EFFECT = '!some(where (p_eft == deny))';
+    const ALLOW_AND_DENY_EFFECT = 'some(where (p_eft == allow)) && !some(where (p_eft == deny))';
+    const PRIORITY_EFFECT = 'priority(p_eft) || deny';
+    const SUBJECT_PRIORITY_EFFECT = 'subjectPriority(p_eft) || deny';
+}

--- a/src/Effector/DefaultEffector.php
+++ b/src/Effector/DefaultEffector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Casbin\Effector;
 
+use Casbin\Constant\Constants;
 use Casbin\Exceptions\CasbinException;
 
 /**
@@ -32,7 +33,7 @@ class DefaultEffector extends Effector
         $explainIndex = -1;
 
         switch ($expr) {
-            case "some(where (p_eft == allow))":
+            case Constants::ALLOW_OVERRIDE_EFFECT:
                 if ($matches[$policyIndex] == 0) {
                     break;
                 }
@@ -43,7 +44,7 @@ class DefaultEffector extends Effector
                     break;
                 }
                 break;
-            case "!some(where (p_eft == deny))":
+            case Constants::DENY_OVERRIDE_EFFECT:
                 // only check the current policyIndex
                 if ($matches[$policyIndex] != 0 && $effects[$policyIndex] === Effector::DENY) {
                     $result = Effector::DENY;
@@ -55,7 +56,7 @@ class DefaultEffector extends Effector
                     $result = Effector::ALLOW;
                 }
                 break;
-            case "some(where (p_eft == allow)) && !some(where (p_eft == deny))":
+            case Constants::ALLOW_AND_DENY_EFFECT:
                 // short-circuit if matched deny rule
                 if ($matches[$policyIndex] != 0 && $effects[$policyIndex] === Effector::DENY) {
                     $result = Effector::DENY;
@@ -83,8 +84,8 @@ class DefaultEffector extends Effector
                     }
                 }
                 break;
-            case "priority(p_eft) || deny":
-            case "subjectPriority(p_eft) || deny":
+            case Constants::PRIORITY_EFFECT:
+            case Constants::SUBJECT_PRIORITY_EFFECT:
                 // reverse merge, short-circuit may be earlier
                 for ($i = count($effects) - 1; $i >= 0; $i--) {
                     if ($matches[$i] == 0) {

--- a/src/InternalEnforcer.php
+++ b/src/InternalEnforcer.php
@@ -342,23 +342,4 @@ class InternalEnforcer extends CoreEnforcer
     
         return $ruleChanged;
     }
-
-    /**
-     * Undocumented function
-     *
-     * @param string $ptype
-     * @return int
-     */
-    protected function getDomainIndex(string $ptype): int
-    {
-        $p = $this->model['p'][$ptype];
-        $pattern = sprintf("%s_dom", $ptype);
-        $index = count($p->tokens);
-
-        $tempIndex = array_search($pattern, $p->tokens);
-        if ($tempIndex !== false) {
-            $index = intval($tempIndex);
-        }
-        return $index;
-    }
 }

--- a/src/ManagementEnforcer.php
+++ b/src/ManagementEnforcer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Casbin;
 
+use Casbin\Constant\Constants;
 use Closure;
 
 /**
@@ -20,7 +21,7 @@ class ManagementEnforcer extends InternalEnforcer
      */
     public function getAllSubjects(): array
     {
-        return $this->model->getValuesForFieldInPolicyAllTypes('p', 0);
+        return $this->model->getValuesForFieldInPolicyAllTypesByName('p', Constants::SUBJECT_INDEX);
     }
 
     /**
@@ -32,7 +33,8 @@ class ManagementEnforcer extends InternalEnforcer
      */
     public function getAllNamedSubjects(string $ptype): array
     {
-        return $this->model->getValuesForFieldInPolicy('p', $ptype, 0);
+        $fieldIndex = $this->model->getFieldIndex('p', Constants::SUBJECT_INDEX);
+        return $this->model->getValuesForFieldInPolicy('p', $ptype, $fieldIndex);
     }
 
     /**
@@ -42,7 +44,7 @@ class ManagementEnforcer extends InternalEnforcer
      */
     public function getAllObjects(): array
     {
-        return $this->model->getValuesForFieldInPolicyAllTypes('p', 1);
+        return $this->model->getValuesForFieldInPolicyAllTypesByName('p', Constants::OBJECT_INDEX);
     }
 
     /**
@@ -54,7 +56,8 @@ class ManagementEnforcer extends InternalEnforcer
      */
     public function getAllNamedObjects(string $ptype): array
     {
-        return $this->model->getValuesForFieldInPolicy('p', $ptype, 1);
+        $fieldIndex = $this->model->getFieldIndex('p', Constants::OBJECT_INDEX);
+        return $this->model->getValuesForFieldInPolicy('p', $ptype, $fieldIndex);
     }
 
     /**
@@ -64,7 +67,7 @@ class ManagementEnforcer extends InternalEnforcer
      */
     public function getAllActions(): array
     {
-        return $this->model->getValuesForFieldInPolicyAllTypes('p', 2);
+        return $this->model->getValuesForFieldInPolicyAllTypesByName('p', Constants::ACTION_INDEX);
     }
 
     /**
@@ -76,7 +79,8 @@ class ManagementEnforcer extends InternalEnforcer
      */
     public function getAllNamedActions(string $ptype): array
     {
-        return $this->model->getValuesForFieldInPolicy('p', $ptype, 2);
+        $fieldIndex = $this->model->getFieldIndex('p', Constants::ACTION_INDEX);
+        return $this->model->getValuesForFieldInPolicy('p', $ptype, $fieldIndex);
     }
 
     /**
@@ -655,5 +659,31 @@ class ManagementEnforcer extends InternalEnforcer
     public function addFunction(string $name, Closure $func): void
     {
         $this->fm->addFunction($name, $func);
+    }
+
+    /**
+     * Gets the index for a given ptype and field.
+     *
+     * @param string $ptype
+     * @param string $field
+     * 
+     * @return int $fieldIndex
+     * @throws Exceptions\CasbinException
+     */
+    public function getFieldIndex(string $ptype, string $field): int
+    {
+        return $this->model->getFieldIndex($ptype, $field);
+    }
+
+    /**
+     * Sets the index for a given ptype and field.
+     *
+     * @param string $ptype
+     * @param string $field
+     * @param int $index
+     */
+    public function setFieldIndex(string $ptype, string $field, int $index): void
+    {
+        $this->model->setFieldIndex($ptype, $field, $index);
     }
 }

--- a/src/Model/Assertion.php
+++ b/src/Model/Assertion.php
@@ -59,16 +59,11 @@ class Assertion
     public $rm;
 
     /**
-     * $priorityIndex.
-     *
-     * @var int|bool
+     * $fieldIndexMap
+     * 
+     * @var array<string, int>
      */
-    public $priorityIndex;
-
-    public function initPriorityIndex(): void
-    {
-        $this->priorityIndex = false;
-    }
+    public $fieldIndexMap = [];
 
     /**
      * @param RoleManager $rm

--- a/src/Model/Policy.php
+++ b/src/Model/Policy.php
@@ -198,10 +198,7 @@ abstract class Policy implements ArrayAccess
         $assertion->policy[] = $rule;
         $assertion->policyMap[implode(self::DEFAULT_SEP, $rule)] = count($this->items[$sec][$ptype]->policy) - 1;
 
-        $hasPriority = false;
-        if (isset($assertion->fieldIndexMap[Constants::PRIORITY_INDEX])) {
-            $hasPriority = true;
-        }
+        $hasPriority = isset($assertion->fieldIndexMap[Constants::PRIORITY_INDEX]);
         if ($sec == 'p' && $hasPriority) {
             $idxInsert = $rule[$assertion->fieldIndexMap[Constants::PRIORITY_INDEX]];
             for($i = count($assertion->policy) - 1; $i > 0; $i--) {

--- a/tests/Unit/ManagementEnforcerTest.php
+++ b/tests/Unit/ManagementEnforcerTest.php
@@ -57,6 +57,16 @@ class ManagementEnforcerTest extends TestCase
         $this->assertEquals($e->getAllRoles(), ['data2_admin']);
     }
 
+    public function testGetListWithDomains()
+    {
+        $e = new Enforcer($this->modelAndPolicyPath . '/rbac_with_domains_model.conf', $this->modelAndPolicyPath . '/rbac_with_domains_policy.csv');
+
+        $this->assertEquals($e->getAllSubjects(), ['admin']);
+        $this->assertEquals($e->getAllObjects(), ['data1', 'data2']);
+        $this->assertEquals($e->getAllActions(), ['read', 'write']);
+        $this->assertEquals($e->getAllRoles(), ['admin']);
+    }
+
     public function testGetPolicyAPI()
     {
         $e = new Enforcer($this->modelAndPolicyPath . '/rbac_model.conf', $this->modelAndPolicyPath . '/rbac_policy.csv');


### PR DESCRIPTION
Unlike the `Casbin Golang` version, some structures have been adjusted, such as placing the implementation of the `GetFieldIndex` and `SetFieldIndex` methods in the Policy class and public them in the `ManagementEnforcer`. I hope this is acceptable. In addition, this PR fixes the issue of `GetAllObjects` and other methods returning incorrect result based on the latest Golang version, and also adds new unit tests. plz review:).