### PR TITLE
feat: upgrade project to support PHP 8 only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
         stability: [ prefer-lowest, prefer-stable ]
 
     name: Test PHP ${{ matrix.php }} - ${{ matrix.stability }}
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.1, 8.0]
+        php: [8.0, 8.1]
 
     name: Benchmark PHP ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ production-ready | production-ready | production-ready | production-ready
 [![python](https://casbin.org/img/langs/python.png)](https://github.com/casbin/pycasbin) | [![dotnet](https://casbin.org/img/langs/dotnet.png)](https://github.com/casbin/Casbin.NET) | [![c++](https://casbin.org/img/langs/cpp.png)](https://github.com/casbin/casbin-cpp) | [![rust](https://casbin.org/img/langs/rust.png)](https://github.com/casbin/casbin-rs)
 ----|----|----|----
 [PyCasbin](https://github.com/casbin/pycasbin) | [Casbin.NET](https://github.com/casbin/Casbin.NET) | [Casbin-CPP](https://github.com/casbin/casbin-cpp) | [Casbin-RS](https://github.com/casbin/casbin-rs)
-production-ready | production-ready | beta-test | production-ready
+production-ready | production-ready | production-ready | production-ready
 
 ## Installation
 
@@ -190,11 +190,11 @@ Priority | [priority_model.conf](https://github.com/php-casbin/php-casbin/blob/m
 
 ## Middlewares
 
-Authz middlewares for web frameworks: https://casbin.org/docs/en/middlewares
+Authz middlewares for web frameworks: https://casbin.org/docs/middlewares
 
 ## Our adopters
 
-https://casbin.org/docs/en/adopters
+https://casbin.org/docs/adopters
 
 ## Contributors
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,7 +23,7 @@ production-ready | production-ready | production-ready | production-ready
 [![python](https://casbin.org/img/langs/python.png)](https://github.com/casbin/pycasbin) | [![dotnet](https://casbin.org/img/langs/dotnet.png)](https://github.com/casbin/Casbin.NET) | [![c++](https://casbin.org/img/langs/cpp.png)](https://github.com/casbin/casbin-cpp) | [![rust](https://casbin.org/img/langs/rust.png)](https://github.com/casbin/casbin-rs)
 ----|----|----|----
 [PyCasbin](https://github.com/casbin/pycasbin) | [Casbin.NET](https://github.com/casbin/Casbin.NET) | [Casbin-CPP](https://github.com/casbin/casbin-cpp) | [Casbin-RS](https://github.com/casbin/casbin-rs)
-production-ready | production-ready | beta-test | production-ready
+production-ready | production-ready | production-ready | production-ready
 
 ## 安装
 
@@ -142,7 +142,7 @@ Casbin 不做的事情:
 
 ## 文档
 
-https://casbin.org/docs/zh-CN/overview
+https://casbin.org/zh/docs/overview
 
 ## 在线编辑器
 
@@ -150,7 +150,7 @@ https://casbin.org/docs/zh-CN/overview
 
 ## 教程
 
-https://casbin.org/docs/zh-CN/tutorials
+https://casbin.org/zh/docs/tutorials
 
 ## Policy管理
 
@@ -173,10 +173,10 @@ Casbin 提供两组 API 来管理权限:
 
 Adapter | Type | Author | Description
 ----|------|----|----
-[File Adapter (内置)](https://casbin.org/docs/zh-CN/policy-storage#file-adapter-built-in) | File | php-casbin | 存储到[.CSV (Comma-Separated Values)](https://en.wikipedia.org/wiki/Comma-separated_values) 文件中
+[File Adapter (内置)](https://casbin.org/zh/policy-storage#file-adapter-built-in) | File | php-casbin | 存储到[.CSV (Comma-Separated Values)](https://en.wikipedia.org/wiki/Comma-separated_values) 文件中
 [Database Adapter](https://github.com/php-casbin/database-adapter) | Database | php-casbin | 支持存储到MySQL, PostgreSQL, SQLite, Microsoft SQL Server数据库的适配器
 
-更多适配器的内容，请参考文档: https://casbin.org/docs/zh-CN/policy-storage
+更多适配器的内容，请参考文档: https://casbin.org/zh/docs/policy-storage/
 
 ## Role管理
 
@@ -208,13 +208,13 @@ Priority | [priority_model.conf](https://github.com/php-casbin/php-casbin/blob/m
 
 ### Web框架
 
-- [Laravel](https://laravel.com/): 为WEB艺术家创造的PHP框架, 通过这个扩展: [laravel-casbin](https://github.com/php-casbin/laravel-casbin)
+- [Laravel](https://laravel.com/): 为WEB艺术家创造的PHP框架, 通过这个扩展: [Laravel-Authorization](https://github.com/php-casbin/laravel-authz)
 
-- [Yii PHP Framework](https://www.yiiframework.com/): 一个高性能的，适用于开发WEB2.0应用的PHP框架, 通过这个扩展: [yii-casbin](https://github.com/php-casbin/yii-casbin)
+- [Yii PHP Framework](https://www.yiiframework.com/): 一个高性能的，适用于开发WEB2.0应用的PHP框架, 通过这个扩展: [Yii-Permission](https://github.com/php-casbin/yii-permission)
 
-- [CakePHP](https://cakephp.org/): 快速、稳定的PHP框架, 通过这个扩展: [cake-casbin](https://github.com/php-casbin/cake-casbin)
+- [CakePHP](https://cakephp.org/): 快速、稳定的PHP框架, 通过这个扩展: [Cake-Permission](https://github.com/php-casbin/cake-permission)
 
-- [ThinkPHP](http://www.thinkphp.cn/): 一个免费开源的，快速、简单的面向对象的轻量级PHP开发框架, 通过这个扩展: [think-casbin](https://github.com/php-casbin/think-casbin)
+- [ThinkPHP](http://www.thinkphp.cn/): 一个免费开源的，快速、简单的面向对象的轻量级PHP开发框架, 通过这个扩展: [Think-Authorization](https://github.com/php-casbin/think-authz)
 
 ## 协议
 

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,8 @@
         "access control"
     ],
     "require": {
-        "php": ">=7.1.0",
-        "symfony/expression-language": "^3.4|^4.0|^5.0|^6.0|^7.0",
-        "s1lentium/iptools": "^1.1"
+        "php": ">=8.0",
+        "symfony/expression-language": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -28,10 +27,10 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.0|~8.0|~9.0",
-        "php-coveralls/php-coveralls": "^2.1",
-        "phpstan/phpstan": "^1.2",
-        "mockery/mockery": "^1.2"
+        "phpunit/phpunit": "~9.0",
+        "php-coveralls/php-coveralls": "^2.4",
+        "phpstan/phpstan": "^1.11",
+        "mockery/mockery": "^1.6"
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,8 @@
 parameters:
     reportUnmatchedIgnoredErrors: false
-    checkMissingIterableValueType: false
     tipsOfTheDay: false
     level: 7
     paths:
         - src
+    ignoreErrors:
+        - identifier: missingType.iterableValue

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -111,17 +111,19 @@ final class Config implements ConfigContract
         $canWrite = null;
 
         $buf = preg_replace('/[\r\n]+/', PHP_EOL, $buf);
-        $buf = explode(PHP_EOL, $buf == null ? "" : $buf);
+        $buf = explode(PHP_EOL, $buf ?? '');
 
-        for ($i = 0, $len = \count($buf); $i <= $len; ++$i) {
+        $len = \count($buf);
+
+        for ($i = 0; $i <= $len; ++$i) {
             if ($canWrite) {
                 $this->write($section, $lineNum, $buffer);
                 $canWrite = false;
             }
 
             ++$lineNum;
-            $line = isset($buf[$i]) ? $buf[$i] : '';
-            if ($i == \count($buf)) {
+            $line = $buf[$i] ?? '';
+            if ($i == $len) {
                 if (\strlen($buffer) > 0) {
                     $this->write($section, $lineNum, $buffer);
                 }
@@ -256,6 +258,6 @@ final class Config implements ConfigContract
             $option = $keys[0];
         }
 
-        return isset($this->data[$section][$option]) ? $this->data[$section][$option] : '';
+        return $this->data[$section][$option] ?? '';
     }
 }

--- a/src/Enforcer.php
+++ b/src/Enforcer.php
@@ -528,7 +528,7 @@ class Enforcer extends ManagementEnforcer
         $objectConditions = [];
         foreach ($permission as $policy) {
             if ($policy[2] == $action) {
-                if (strpos($policy[1], $prefix) !== 0) {
+                if (!str_starts_with($policy[1], $prefix)) {
                     throw new ObjConditionException('need to meet the prefix required by the object condition');
                 }
 

--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -302,7 +302,7 @@ class Model extends Policy
         foreach ($this->items['p'] as $ptype => $assertion) {
             try {
                 $domainIndex = $this->getFieldIndex($ptype, Constants::DOMAIN_INDEX);
-            } catch (CasbinException $e) {
+            } catch (CasbinException) {
                 $domainIndex = -1;
             }
             $policies = &$assertion->policy;
@@ -338,7 +338,7 @@ class Model extends Policy
         foreach ($this->items['p'] as $ptype => $assertion) {
             try {
                 $priorityIndex = $this->getFieldIndex($ptype, Constants::PRIORITY_INDEX);
-            } catch (CasbinException $e) {
+            } catch (CasbinException) {
                 continue;
             }
             $policies = &$assertion->policy;

--- a/src/Persist/Adapters/FileFilteredAdapter.php
+++ b/src/Persist/Adapters/FileFilteredAdapter.php
@@ -143,17 +143,11 @@ class FileFilteredAdapter extends FileAdapter implements FilteredAdapter
             return true;
         }
 
-        $filterSlice = [];
-        switch (trim($p[0])) {
-            case 'p':
-                $filterSlice = $filter->p;
-
-                break;
-            case 'g':
-                $filterSlice = $filter->g;
-
-                break;
-        }
+        $filterSlice = match (trim($p[0])) {
+            'p' => $filter->p,
+            'g' => $filter->g,
+            default => []
+        };
 
         return self::filterWords($p, $filterSlice);
     }

--- a/src/Util/BuiltinOperations.php
+++ b/src/Util/BuiltinOperations.php
@@ -28,7 +28,7 @@ class BuiltinOperations
      */
     public static function keyMatch(string $key1, string $key2): bool
     {
-        if (false === strpos($key2, '*')) {
+        if (!str_contains($key2, '*')) {
             return $key1 == $key2;
         }
 
@@ -364,11 +364,7 @@ class BuiltinOperations
      */
     public static function ipMatch(string $ip1, string $ip2): bool
     {
-        $objIP1 = IP::parse($ip1);
-
-        $objIP2 = Range::parse($ip2);
-
-        return $objIP2->contains($objIP1);
+        return Util::ipInSubnet($ip1, $ip2);
     }
 
     /**
@@ -433,7 +429,7 @@ class BuiltinOperations
         return function (...$args) use ($rm, &$memorized) {
             $key = implode(chr(0b0), $args);
 
-            if(isset($memorized[$key])){
+            if (isset($memorized[$key])) {
                 return $memorized[$key];
             }
 

--- a/tests/Benchmark/ModelBenchmarkTest.php
+++ b/tests/Benchmark/ModelBenchmarkTest.php
@@ -198,7 +198,7 @@ class ModelBenchmarkTest extends TestCase
             $closure();
         }
         $x = microtime(true) - $x;
-        $fn = isset(debug_backtrace()[1]['function']) ? debug_backtrace()[1]['function'] : __FUNCTION__;
+        $fn = debug_backtrace()[1]['function'] ?? __FUNCTION__;
         printf(
             "%s %s %s ms/op". PHP_EOL,
             str_pad($fn, 45, " ", STR_PAD_RIGHT),

--- a/tests/Unit/CoreEnforcerTest.php
+++ b/tests/Unit/CoreEnforcerTest.php
@@ -60,7 +60,7 @@ class CoreEnforcerTest extends TestCase
 
     public function testInitEmpty()
     {
-        $e = new Enforcer(true);
+        $e = new Enforcer(enableLog: true);
 
         $m = Model::newModelFromString(
             <<<'EOT'

--- a/tests/Unit/Util/BuiltinOperationsTest.php
+++ b/tests/Unit/Util/BuiltinOperationsTest.php
@@ -42,14 +42,24 @@ class BuiltinOperationsTest extends TestCase
         return BuiltinOperations::globMatchFunc($name1, $name2);
     }
 
-    public function keyGetFunc($name1, $name2)
+    private function keyGetFunc($name1, $name2)
     {
         return BuiltinOperations::KeyGetFunc($name1, $name2);
     }
 
-    public function keyGet2Func($name1, $name2, $pathVar)
+    private function keyGet2Func($name1, $name2, $pathVar)
     {
         return BuiltinOperations::KeyGet2Func($name1, $name2, $pathVar);
+    }
+
+    private function regexMatchFunc($name1, $name2)
+    {
+        return BuiltinOperations::regexMatchFunc($name1, $name2);
+    }
+
+    private function ipMatchFunc($ip1, $ip2)
+    {
+        return BuiltinOperations::ipMatchFunc($ip1, $ip2);
     }
 
     public function testKeyMatchFunc()
@@ -208,5 +218,37 @@ class BuiltinOperationsTest extends TestCase
         $this->assertEquals('', $this->keyGet2Func("/alice/all", "/:id", "id"));
 
         $this->assertEquals('', $this->keyGet2Func("/alice/all", "/:/all", ""));
+    }
+
+    public function testRegexMatchFunc()
+    {
+        $this->assertTrue($this->regexMatchFunc("/topic/create", "/topic/create"));
+        $this->assertTrue($this->regexMatchFunc("/topic/create/123", "/topic/create"));
+        $this->assertFalse($this->regexMatchFunc("/topic/delete", "/topic/create"));
+        $this->assertFalse($this->regexMatchFunc("/topic/edit", "/topic/edit/[0-9]+"));
+        $this->assertTrue($this->regexMatchFunc("/topic/edit/123", "/topic/edit/[0-9]+"));
+        $this->assertFalse($this->regexMatchFunc("/topic/edit/abc", "/topic/edit/[0-9]+"));
+        $this->assertFalse($this->regexMatchFunc("/foo/delete/123", "/topic/delete/[0-9]+"));
+        $this->assertTrue($this->regexMatchFunc("/topic/delete/0", "/topic/delete/[0-9]+"));
+        $this->assertFalse($this->regexMatchFunc("/topic/edit/123s", "/topic/delete/[0-9]+"));
+    }
+
+    public function testIPMatchFunc()
+    {
+        // ipv4
+        $this->assertTrue($this->ipMatchFunc("192.168.2.123", "192.168.2.0/24"));
+        $this->assertFalse($this->ipMatchFunc("192.168.2.123", "192.168.3.0/24"));
+        $this->assertTrue($this->ipMatchFunc("192.168.2.123", "192.168.2.0/16"));
+        $this->assertTrue($this->ipMatchFunc("192.168.2.123", "192.168.2.123"));
+        $this->assertTrue($this->ipMatchFunc("192.168.2.123", "192.168.2.123/32"));
+        $this->assertTrue($this->ipMatchFunc("10.0.0.11", "10.0.0.0/8"));
+        $this->assertFalse($this->ipMatchFunc("11.0.0.123", "10.0.0.0/8"));
+        // ipv6
+        $this->assertTrue($this->ipMatchFunc('2001:db8::ffff', '2001:db8::/64'));
+        $this->assertTrue($this->ipMatchFunc('2a00:1450:400c:c04::6a', '2a00:1450::/32'));
+        $this->assertFalse($this->ipMatchFunc('2001:db8:ffff::', '2001:db8::/64'));
+        $this->assertTrue($this->ipMatchFunc('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::/64'));
+        $this->assertTrue($this->ipMatchFunc('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3:1319:8a2e:0370:7347'));
+        $this->assertFalse($this->ipMatchFunc('2001:0db8:85a3:08d3:1319:8a2e:0370:7347', '2001:0db8:85a3:08d3::'));
     }
 }


### PR DESCRIPTION
- Updated README and README_CN
  - Fixed broken links
  - Synced latest content
- Updated composer.json
  - Required PHP 8
  - Synced and upgraded dependencies to the latest versions
  - Removed dependency on `s1lentium/iptools`
- Updated CI configuration
  - Removed tests for PHP 7.x
- Utilized PHP 8 syntax features
  - Nullsafe operator
  - Match expression
  - Replaced functions with `str_contains` and `str_starts_with`
  - Used union types for better type handling