### PR TITLE
feat: Implement CachedEnforcer with Symfony Cache component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "php": ">=8.0",
-        "symfony/expression-language": "^6.0|^7.0"
+        "symfony/expression-language": "^6.0|^7.0",
+        "symfony/cache": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/CachedEnforcer.php
+++ b/src/CachedEnforcer.php
@@ -4,45 +4,55 @@ declare(strict_types=1);
 
 namespace Casbin;
 
+use Casbin\Contracts\CacheableParam;
+use Casbin\Exceptions\CasbinException;
+use Casbin\Log\Log;
+use Casbin\Model\Model;
+use Casbin\Persist\Adapter;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
 /**
  * Class CachedEnforcer
  * Wraps Enforcer and provides decision cache.
+ * It is implemented using Symfony's Cache component, which supports multiple cache adapters such as 
+ * filesystem, Redis, or Memcached. By default, it uses the `FilesystemAdapter` for local file-based caching.
  *
  * @author techlee@qq.com
+ * @author 1692898084@qq.com
  */
 class CachedEnforcer extends Enforcer
 {
     /**
-     * @var array
+     * @var int|null
      */
-    public static $m = [];
+    protected ?int $expireTime;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    protected CacheItemPoolInterface $cache;
 
     /**
      * @var bool
      */
-    protected $enableCache;
+    protected bool $enableCache;
 
     /**
      * CachedEnforcer constructor.
      *
-     * @param mixed ...$params
-     *
-     * @throws Exceptions\CasbinException
+     * @param string|Model|null $model
+     * @param string|Adapter|null $adapter
+     * @param bool|null $enableLog
+     * 
+     * @throws CasbinException
      */
-    public function __construct(...$params)
+    public function __construct(string|Model|null $model = null, string|Adapter|null $adapter = null, ?bool $enableLog = null)
     {
-        parent::__construct(...$params);
         $this->enableCache = true;
-    }
-
-    /**
-     * Determines whether to enable cache on Enforce(). When enableCache is enabled, cached result (true | false) will be returned for previous decisions.
-     *
-     * @param bool $enableCache
-     */
-    public function enableCache(bool $enableCache): void
-    {
-        $this->enableCache = $enableCache;
+        $this->cache = new ArrayAdapter();
+        $this->expireTime = null;
+        parent::__construct($model, $adapter, $enableLog);
     }
 
     /**
@@ -61,30 +71,190 @@ class CachedEnforcer extends Enforcer
             return parent::enforce(...$rvals);
         }
 
-        $key = '';
-        foreach ($rvals as $rval) {
-            if (is_string($rval)) {
-                $key .= $rval.'$$';
-            } else {
-                return  parent::enforce(...$rvals);
-            }
-        }
-
-        if (isset(self::$m[$key])) {
-            return self::$m[$key];
-        } else {
-            $res = parent::enforce(...$rvals);
-            self::$m[$key] = $res;
-
+        $key = $this->getKey(...$rvals);
+        $res = $this->getCachedResult($key);
+        if (!is_null($res)) {
             return $res;
         }
+
+        $value = parent::enforce(...$rvals);
+        $this->setCachedResult($key, $value);
+        return $value;
     }
 
     /**
-     * Deletes all the existing cached decisions.
+     * Determines whether to enable cache on Enforce(). When enableCache is enabled, cached result (true | false) will be returned for previous decisions.
+     *
+     * @param bool $enableCache
+     * 
+     * @return void
+     */
+    public function enableCache(bool $enableCache = true): void
+    {
+        $this->enableCache = $enableCache;
+    }
+
+
+    /**
+     * Sets the cache adapter for the enforcer.
+     * 
+     *
+     * @param CacheItemPoolInterface $cache
+     * 
+     * @return void
+     */
+    public function setCache(CacheItemPoolInterface $cache): void
+    {
+        $this->cache = $cache;
+    }
+
+
+    /**
+     * Sets the expire time for the cache in seconds. If the value is null, the cache will never expire.
+     *
+     * @param int|null $expireTime
+     * 
+     * @return void
+     */
+    public function setExpireTime(int|null $expireTime): void
+    {
+        $this->expireTime = $expireTime;
+    }
+
+    /**
+     * Invalidates the cache.
      */
     public function invalidateCache(): void
     {
-        self::$m = [];
+        $this->cache->clear();
+    }
+
+    /**
+     * Reloads the policy from file/database.
+     */
+    public function loadPolicy(): void
+    {
+        if ($this->enableCache) {
+            $this->cache->clear();
+        }
+
+        parent::loadPolicy();
+    }
+
+    /**
+     * Removes an authorization rule from the current policy.
+     *
+     * @param mixed ...$params
+     *
+     * @return bool
+     */
+    public function removePolicy(...$params): bool
+    {
+        if ($this->enableCache) {
+            $key = $this->getKey(...$params);
+            $this->cache->deleteItem($key);
+        }
+
+        return parent::removePolicy(...$params);
+    }
+
+    /**
+     * Removes an authorization rules from the current policy.
+     *
+     * @param array $rules
+     *
+     * @return bool
+     */
+    public function removePolicies(array $rules): bool
+    {
+        if ($this->enableCache) {
+            foreach ($rules as $rule) {
+                $key = $this->getKey(...$rule);
+                $this->cache->deleteItem($key);
+            }
+        }
+
+        return parent::removePolicies($rules);
+    }
+
+    /**
+     * Clears all policy.
+     */
+    public function clearPolicy(): void
+    {
+        if ($this->enableCache) {
+            if (!$this->cache->clear()) {
+                Log::logPrint('clear cache failed');
+            }
+        }
+
+        parent::clearPolicy();
+    }
+
+    /**
+     * Gets the cached result from the cache by key.
+     *
+     * If the key does not exist in the cache, it returns null.
+     *
+     * @param string $key
+     *
+     * @return bool|null
+     */
+    public function getCachedResult(string $key): bool|null
+    {
+        $value = $this->cache->getItem($key)->get();
+        return $value;
+    }
+
+    /**
+     * Sets the cached result to the cache by key.
+     *
+     * @param string $key
+     * @param bool $value
+     *
+     * @return void
+     */
+    public function setCachedResult(string $key, bool $value): void
+    {
+        $item = $this->cache->getItem($key);
+        $item->set($value);
+        $item->expiresAfter($this->expireTime);
+        $this->cache->save($item);
+    }
+
+    /**
+     * Gets the cache key by combining the input parameters.
+     * 
+     * @param mixed ...$rvals
+     *
+     * @return string
+     */
+    public function getCacheKey(...$rvals): string
+    {
+        $key = '';
+        foreach ($rvals as $rval) {
+            if (is_string($rval)) {
+                $key .= $rval;
+            } elseif ($rval instanceof CacheableParam) {
+                $key .= $rval->getCacheKey();
+            } else {
+                return '';
+            }
+            $key .= '$$';
+        }
+
+        return $key;
+    }
+
+    /**
+     * Gets the cache key by combining the input parameters.
+     *
+     * @param mixed ...$rvals
+     *
+     * @return string
+     */
+    private function getKey(...$rvals): string
+    {
+        return $this->getCacheKey(...$rvals);
     }
 }

--- a/src/Contracts/CacheableParam.php
+++ b/src/Contracts/CacheableParam.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Casbin\Contracts;
+
+/**
+ * Interface CacheableParam.
+ * 
+ * @author 1692898084@qq.com
+ */
+interface CacheableParam
+{
+    /**
+     * Returns a cache key.
+     *
+     * @return string
+     */
+    public function getCacheKey(): string;
+}

--- a/src/Util/BuiltinOperations.php
+++ b/src/Util/BuiltinOperations.php
@@ -7,8 +7,6 @@ namespace Casbin\Util;
 use Casbin\Rbac\RoleManager;
 use Closure;
 use Exception;
-use IPTools\IP;
-use IPTools\Range;
 
 /**
  * Class BuiltinOperations.

--- a/tests/Unit/CachedEnforcerTest.php
+++ b/tests/Unit/CachedEnforcerTest.php
@@ -2,8 +2,10 @@
 
 namespace Casbin\Tests\Unit;
 
+use Casbin\Contracts\CacheableParam;
 use PHPUnit\Framework\TestCase;
 use Casbin\CachedEnforcer;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * CachedEnforcerTest.
@@ -17,37 +19,80 @@ class CachedEnforcerTest extends TestCase
     public function testEnforce()
     {
         $e = new CachedEnforcer($this->modelAndPolicyPath . '/basic_model.conf', $this->modelAndPolicyPath . '/basic_policy.csv');
-
+        $e->setExpireTime(60);
+ 
         $this->assertTrue($e->enforce('alice', 'data1', 'read'));
         $this->assertFalse($e->enforce('alice', 'data1', 'write'));
         $this->assertFalse($e->enforce('alice', 'data2', 'read'));
         $this->assertFalse($e->enforce('alice', 'data2', 'write'));
 
         $e->removePolicy('alice', 'data1', 'read');
+        $this->assertFalse($e->removePolicy('alice', 'data1', 'read'));
 
+        $this->assertFalse($e->enforce('alice', 'data1', 'read'));
+        $this->assertFalse($e->enforce('alice', 'data1', 'write'));
+        $this->assertFalse($e->enforce('alice', 'data2', 'read'));
+        $this->assertFalse($e->enforce('alice', 'data2', 'write'));
+
+        $e = new CachedEnforcer($this->modelAndPolicyPath . '/basic_model.conf', $this->modelAndPolicyPath . '/basic_policy.csv');
+        $e->enableCache(false);
+ 
         $this->assertTrue($e->enforce('alice', 'data1', 'read'));
         $this->assertFalse($e->enforce('alice', 'data1', 'write'));
+        $this->assertFalse($e->enforce('alice', 'data2', 'read'));
+        $this->assertFalse($e->enforce('alice', 'data2', 'write'));
+
+        $e = new CachedEnforcer($this->modelAndPolicyPath . '/rbac_model.conf', $this->modelAndPolicyPath . '/rbac_policy.csv');
+        $e->setCache(new ArrayAdapter());
+
+        $this->assertTrue($e->enforce('alice', 'data1', 'read'));
+        $this->assertTrue($e->enforce('bob', 'data2', 'write'));
+        $this->assertTrue($e->enforce('alice', 'data2', 'read'));
+        $this->assertTrue($e->enforce('alice', 'data2', 'write'));
+
+        $e->removePolicies([
+            ['alice', 'data1', 'read'],
+            ['bob', 'data2', 'write'],
+        ]);
+        $this->assertFalse($e->removePolicies([
+            ['alice', 'data1', 'read'],
+            ['bob', 'data2', 'write'],
+        ]));
+
+        $this->assertFalse($e->enforce('alice', 'data1', 'read'));
+        $this->assertFalse($e->enforce('bob', 'data2', 'write'));
+        $this->assertTrue($e->enforce('alice', 'data2', 'read'));
+        $this->assertTrue($e->enforce('alice', 'data2', 'write'));
+
+        $e = new CachedEnforcer($this->modelAndPolicyPath . '/rbac_model.conf', $this->modelAndPolicyPath . '/rbac_policy.csv');
+        $e->loadPolicy();
+
+        $this->assertTrue($e->enforce('alice', 'data1', 'read'));
+        $this->assertTrue($e->enforce('bob', 'data2', 'write'));
+        $this->assertTrue($e->enforce('alice', 'data2', 'read'));
+        $this->assertTrue($e->enforce('alice', 'data2', 'write'));
+
+        $e->clearPolicy();
+
+        $this->assertFalse($e->enforce('alice', 'data1', 'read'));
+        $this->assertFalse($e->enforce('bob', 'data2', 'write'));
         $this->assertFalse($e->enforce('alice', 'data2', 'read'));
         $this->assertFalse($e->enforce('alice', 'data2', 'write'));
 
         $e->invalidateCache();
-
-        $this->assertFalse($e->enforce('alice', 'data1', 'read'));
-        $this->assertFalse($e->enforce('alice', 'data1', 'write'));
-        $this->assertFalse($e->enforce('alice', 'data2', 'read'));
-        $this->assertFalse($e->enforce('alice', 'data2', 'write'));
     }
 
-    public function testEnableCache()
+    public function testGetCacheKey()
     {
         $e = new CachedEnforcer($this->modelAndPolicyPath . '/basic_model.conf', $this->modelAndPolicyPath . '/basic_policy.csv');
 
-        $e->enableCache(false);
-
-        $this->assertTrue($e->enforce('alice', 'data1', 'read'));
-
-        $e->removePolicy('alice', 'data1', 'read');
-
-        $this->assertFalse($e->enforce('alice', 'data1', 'read'));
+        $this->assertEquals('alice$$data1$$read$$', $e->getCacheKey('alice', 'data1', 'read'));
+        $this->assertEquals('alice$$data1$$read$$', $e->getCacheKey(new class() implements CacheableParam {
+            public function getCacheKey(): string
+            {
+                return 'alice';
+            }
+        }, 'data1', 'read'));
+        $this->assertEquals('', $e->getCacheKey('alice', 'data1', true));
     }
 }


### PR DESCRIPTION
- Added CachedEnforcer to integrate Symfony's Cache component for caching functionality.
- Enabled support for multiple cache adapters, allowing flexible switching based on configuration.
- Added methods to control cache usage, improving flexibility and performance in caching decisions.